### PR TITLE
Fix changes for installing all the include headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,7 +288,7 @@ set_target_properties(${PROJECT_NAME}
         SOVERSION ${LIB_VERSION}
         )
 
-dlio_profiler_install_headers(${DLIO_PROFILER_CORE_PUBLIC_INCLUDE})
+dlio_profiler_install_headers("${DLIO_PROFILER_CORE_PUBLIC_INCLUDE}")
 install(
         TARGETS ${PROJECT_NAME}
         EXPORT ${DLIO_PROFILER_EXPORTED_TARGETS}

--- a/cmake/modules/dlio_profiler-utils.cmake
+++ b/cmake/modules/dlio_profiler-utils.cmake
@@ -100,7 +100,7 @@ endmacro ()
 # Install Public includes
 ################################################################
 
-function(dlio_profiler_install_headers public_headers current_dir)
+function(dlio_profiler_install_headers public_headers)
     message("-- [${PROJECT_NAME}] " "installing headers ${public_headers}")
     foreach (header ${public_headers})
         file(RELATIVE_PATH header_file_path "${PROJECT_SOURCE_DIR}/src" "${header}")


### PR DESCRIPTION
Currently, it was only installing the first one as I missed quotes.