### PR TITLE
Interactive sparse Git clone and push scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,6 +502,14 @@ install(
         bin
 )
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/script/git_sparse_push_interactive ${EXECUTABLE_OUTPUT_PATH}/git_sparse_push_interactive COPYONLY)
+install(
+        FILES
+        ${EXECUTABLE_OUTPUT_PATH}/git_sparse_push_interactive
+        DESTINATION
+        bin
+)
+
 #cmake_policy(SET CMP0079 NEW) # In case that we need more control over the target building order
 
 if(DFTRACER_ENABLE_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,6 +502,14 @@ install(
         bin
 )
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/script/git_sparse_clone_interactive ${EXECUTABLE_OUTPUT_PATH}/git_sparse_clone_interactive COPYONLY)
+install(
+        FILES
+        ${EXECUTABLE_OUTPUT_PATH}/git_sparse_clone_interactive
+        DESTINATION
+        bin
+)
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/script/git_sparse_push_interactive ${EXECUTABLE_OUTPUT_PATH}/git_sparse_push_interactive COPYONLY)
 install(
         FILES

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -175,6 +175,24 @@ Arguments for this script are:
 5. **-d input_directory** specify input directories. should contain .pfw or .pfw.gz files.
 
 ------------------
+Sparse Git Clone
+------------------
+
+The script enables sparse git-clone of dftracer traces of the specified branch into 
+the specified local directory. It optionally provides interactive selection of directories to clone.
+
+.. code-block:: bash
+
+    <install-dir>/bin/usage: git_sparse_clone_interactive <remote repository> <branch> <local directory> [directory]
+
+Arguments for this script are:
+
+1. **repository name** name of remote repository
+2. **branch name**     name of remote branch
+3. **local directory** name of local directory to clone into       
+4. **directory**       optional comma-separated list of directories to sparse-clone.
+
+------------------
 Sparse Git Push
 ------------------
 
@@ -187,6 +205,6 @@ and branch. It optionally provides interactive selection of directories to push.
 
 Arguments for this script are:
 
-3. **repository name** name of remote repository
-4. **branch name**     name of remote branch
-5. **directory**       optional comma-separated list of directories to sparse-push.
+1. **repository name** name of remote repository
+2. **branch name**     name of remote branch
+3. **directory**       optional comma-separated list of directories to sparse-push.

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -173,3 +173,20 @@ Arguments for this script are:
 3. **-v** enable verbose mode
 4. **-h** display help
 5. **-d input_directory** specify input directories. should contain .pfw or .pfw.gz files.
+
+------------------
+Sparse Git Push
+------------------
+
+The script enables sparse git-push of dftracer traces to the specified remote repository
+and branch. It optionally provides interactive selection of directories to push.
+
+.. code-block:: bash
+
+    <install-dir>/bin/usage: git_sparse_push_interactive <remote repository> <branch> [directory]
+
+Arguments for this script are:
+
+3. **repository name** name of remote repository
+4. **branch name**     name of remote branch
+5. **directory**       optional comma-separated list of directories to sparse-push.

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -187,10 +187,10 @@ the specified local directory. It optionally provides interactive selection of d
 
 Arguments for this script are:
 
-1. **repository name** name of remote repository
-2. **branch name**     name of remote branch
-3. **local directory** name of local directory to clone into       
-4. **directory**       optional comma-separated list of directories to sparse-clone.
+1. **-r repository name** name of remote repository
+2. **-b branch name**     name of remote branch
+3. **-l local directory** name of local directory to clone into       
+4. **-d directory**       optional comma-separated list of directories to sparse-clone.
 
 ------------------
 Sparse Git Push
@@ -205,6 +205,6 @@ and branch. It optionally provides interactive selection of directories to push.
 
 Arguments for this script are:
 
-1. **repository name** name of remote repository
-2. **branch name**     name of remote branch
-3. **directory**       optional comma-separated list of directories to sparse-push.
+1. **-r repository name** name of remote repository
+2. **-b branch name**     name of remote branch
+3. **-d directory**       optional comma-separated list of directories to sparse-push.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ script-files = [
   "script/dftracer_event_count",
   "script/dftracer_validate",
   "script/dftracer_pgzip",
+  "script/git_sparse_clone_interactive",
   "script/git_sparse_push_interactive",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ script-files = [
   "script/dftracer_event_count",
   "script/dftracer_validate",
   "script/dftracer_pgzip",
+  "script/git_sparse_push_interactive",
 ]
 
 [tool.setuptools.package-dir]

--- a/script/git_sparse_clone_interactive
+++ b/script/git_sparse_clone_interactive
@@ -3,10 +3,10 @@
 # the repository.
 # Example usage: 
 #   For interactive usage:
-#   ./git_sparse_clone_interactive.sh ssh://git@czgitlab.llnl.gov:7999/iopp/dftracer-traces.git v1.0.10.dev7/corona dft-test1  
+#   ./git_sparse_clone_interactive.sh -r ssh://git@czgitlab.llnl.gov:7999/iopp/dftracer-traces.git -b v1.0.10.dev7/corona -l dft-test1
 #
-#   For non-interative usage: 
-#   ./git_sparse_clone_interactive.sh ssh://git@czgitlab.llnl.gov:7999/iopp/dftracer-traces.git v1.0.10.dev7/corona dft-test1 bert_v100,resnet50_v100
+#   For non-interactive usage: 
+#   ./git_sparse_clone_interactive.sh -r ssh://git@czgitlab.llnl.gov:7999/iopp/dftracer-traces.git -b v1.0.10.dev7/corona -l dft-test1 -d bert_v100,resnet50_v100
 #  !! For non-interactive usage, please make sure to not include spaces between names of dirs
 #     as shown above !!
 
@@ -17,39 +17,45 @@ IFS=$'\n\t'
 
 usage() {
   cat <<EOF
-Usage: $0 <repo_url> <branch> <localdir> [dir1[,dir2,...]]
+Usage: $0 -r <repo_url> -b <branch> -l <localdir> [-d <dir1[,dir2,...]>]
 
-  <repo_url>   Git repository URL (e.g., ssh://git@.../project.git)
-  <branch>     Branch to sparse-checkout (e.g., v1.0.10.dev7/corona)
-  <localdir>   Local folder name for the clone (will be created if missing)
-  [dirs]       Optional comma-separated list of paths
-               to sparse-checkout. If omitted, interactive menus are shown 
-               (specify item numbers to select directories to clone).
+  -r   Git repository URL (e.g., ssh://git@.../project.git)
+  -b   Branch to sparse-checkout (e.g., v1.0.10.dev7/corona)
+  -l   Local folder name for the clone (will be created if missing)
+  -d   Optional comma-separated list of paths
+       to sparse-checkout. If omitted, interactive menus are shown 
+       (specify item numbers to select directories to clone).
 EOF
   exit 1
 }
 
-#require at least repo URL, branch, and local directory
-if [ $# -lt 3 ]; then
-  usage
-fi
-
-#parse mandatory args
-rurl=$1
-branch=$2
-localdir=$3
-shift 3
-
-#parse optional arg
+#parse options
+rurl=""
+branch=""
+localdir=""
 declare -a patterns
 skip_interactive=0
-if [ $# -ge 1 ]; then
-  skip_interactive=1
-  if [[ "$*" == *","* ]]; then
-    IFS=',' read -ra patterns <<< "$*"
-  else
-    patterns=("$@")
-  fi
+
+while getopts ":r:b:l:d:" opt; do
+  case $opt in
+    r) rurl="$OPTARG" ;;
+    b) branch="$OPTARG" ;;
+    l) localdir="$OPTARG" ;;
+    d) skip_interactive=1
+       if [[ "$OPTARG" == *","* ]]; then
+         IFS=',' read -ra patterns <<< "$OPTARG"
+       else
+         patterns=("$OPTARG")
+       fi
+       ;;
+    :) echo "Error: Option -$OPTARG requires an argument." >&2; usage ;;
+    \?) echo "Error: Invalid option -$OPTARG" >&2; usage ;;
+  esac
+done
+
+#check mandatory args
+if [[ -z "$rurl" || -z "$branch" || -z "$localdir" ]]; then
+  usage
 fi
 
 #clone metadata if needed

--- a/script/git_sparse_clone_interactive
+++ b/script/git_sparse_clone_interactive
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# This script is intended to be run at the top-level directory where you want to sparse-clone
+# the repository.
+# Example usage: 
+#   For interactive usage:
+#   ./git_sparse_clone_interactive.sh ssh://git@czgitlab.llnl.gov:7999/iopp/dftracer-traces.git v1.0.10.dev7/corona dft-test1  
+#
+#   For non-interative usage: 
+#   ./git_sparse_clone_interactive.sh ssh://git@czgitlab.llnl.gov:7999/iopp/dftracer-traces.git v1.0.10.dev7/corona dft-test1 bert_v100,resnet50_v100
+#  !! For non-interactive usage, please make sure to not include spaces between names of dirs
+#     as shown above !!
+
+#report first error and bail
+set -euo pipefail
+#handle non-trivial names/strings
+IFS=$'\n\t'
+
+usage() {
+  cat <<EOF
+Usage: $0 <repo_url> <branch> <localdir> [dir1[,dir2,...]]
+
+  <repo_url>   Git repository URL (e.g., ssh://git@.../project.git)
+  <branch>     Branch to sparse-checkout (e.g., v1.0.10.dev7/corona)
+  <localdir>   Local folder name for the clone (will be created if missing)
+  [dirs]       Optional comma-separated list of paths
+               to sparse-checkout. If omitted, interactive menus are shown 
+               (specify item numbers to select directories to clone).
+EOF
+  exit 1
+}
+
+#require at least repo URL, branch, and local directory
+if [ $# -lt 3 ]; then
+  usage
+fi
+
+#parse mandatory args
+rurl=$1
+branch=$2
+localdir=$3
+shift 3
+
+#parse optional arg
+declare -a patterns
+skip_interactive=0
+if [ $# -ge 1 ]; then
+  skip_interactive=1
+  if [[ "$*" == *","* ]]; then
+    IFS=',' read -ra patterns <<< "$*"
+  else
+    patterns=("$@")
+  fi
+fi
+
+#clone metadata if needed
+if [ ! -d "$localdir/.git" ]; then
+  git clone -b "$branch" --no-checkout "$rurl" "$localdir" || {
+    echo "Error: clone failed" >&2
+    exit 1
+  }
+fi
+
+pushd "$localdir" >/dev/null
+
+#enable LFS and sparse-checkout
+#not required each time but doesn't hurt
+#also doesn't handle git servers with LFS disabled or not supported
+git lfs install --local >/dev/null 2>&1 || true
+git sparse-checkout init --cone >/dev/null 2>&1 || true
+
+#interactive selection if patterns not provided
+if [ "$skip_interactive" -eq 0 ]; then
+  #list top-level dirs
+  mapfile -t topDirs < <(git ls-tree --name-only -d "$branch")
+  if [ ${#topDirs[@]} -eq 0 ]; then
+    echo "Error: no top-level directories on '$branch'" >&2
+    popd >/dev/null
+    exit 1
+  fi
+  echo
+  echo "Select top-level directories (comma-separated indices) or 'all':"
+  for i in "${!topDirs[@]}"; do
+    printf "%3d) %s\n" "$((i+1))" "${topDirs[i]}"
+  done
+  printf "%3d) all\n" "$(( ${#topDirs[@]} + 1 ))"
+  read -rp "Choice(s): " choice1
+
+  if [[ "$choice1" == "all" ]]; then
+    patterns=("${topDirs[@]}")
+    drill_deeper=0
+  else
+    #parse indices of dirs
+    IFS=',' read -ra idxs <<< "$choice1"
+    for raw in "${idxs[@]}"; do
+      idx=$(echo "$raw" | xargs)
+      if ! [[ "$idx" =~ ^[0-9]+$ ]] || (( idx < 1 || idx > ${#topDirs[@]} )); then
+        echo "Error: invalid index '$raw'" >&2
+        popd >/dev/null
+        exit 1
+      fi
+      patterns+=("${topDirs[idx-1]}")
+    done
+    drill_deeper=0
+    if [ ${#patterns[@]} -eq 1 ]; then
+      drill_deeper=1
+    fi
+  fi
+
+  #optional second-level menu
+  if [ "$drill_deeper" -eq 1 ]; then
+    parent="${patterns[0]}"
+    mapfile -t subdirs < <(git ls-tree --name-only -d "$branch":"$parent")
+    if [ ${#subdirs[@]} -gt 0 ]; then
+      echo
+      echo "Select sub-dirs under '$parent' (indices) or 'all':"
+      for i in "${!subdirs[@]}"; do
+        printf "%3d) %s\n" "$((i+1))" "${subdirs[i]}"
+      done
+      printf "%3d) all\n" "$(( ${#subdirs[@]} + 1 ))"
+      read -rp "Choice(s): " choice2
+
+      unset patterns
+      if [[ "$choice2" == "all" ]]; then
+        for d in "${subdirs[@]}"; do
+          patterns+=("$parent/$d")
+        done
+      else
+        IFS=',' read -ra idxs2 <<< "$choice2"
+        for raw in "${idxs2[@]}"; do
+          idx=$(echo "$raw" | xargs)
+          if ! [[ "$idx" =~ ^[0-9]+$ ]] || (( idx < 1 || idx > ${#subdirs[@]} )); then
+            echo "Error: invalid index '$raw'" >&2
+            popd >/dev/null
+            exit 1
+          fi
+          patterns+=("$parent/${subdirs[idx-1]}")
+        done
+      fi
+    fi
+  fi
+fi
+
+#apply sparse-checkout patterns
+for p in "${patterns[@]}"; do
+  git sparse-checkout add "$p"
+done
+
+#checkout and pull LFS
+git checkout "$branch"
+git lfs pull --include="$(IFS=,; echo "${patterns[*]}")"
+
+popd >/dev/null
+echo "Sparse-checkout complete in '$localdir' for: ${patterns[*]}"

--- a/script/git_sparse_push_interactive
+++ b/script/git_sparse_push_interactive
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# This script is intended to be run at the root of your local clone
+# Example usage: 
+#   For interactive usage:
+#   ./git_sparse_push_interactive.sh upstream v1.0.10.dev6/corona   
+#
+#   For non-interative usage: 
+#   ./git_sparse_push_interactive.sh upstream v1.0.10.dev6/corona test_app3_v100,test_app4_v100
+#  !! For non-interactive usage, please make sure to not include spaces between names of dirs
+#     as shown above
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# git-sparse-push-interactive.sh
+# Interactive script to add directories to sparse-checkout, commit, and push.
+
+usage() {
+  cat <<EOF
+Usage: $0 <remote> <branch> [dir1[,dir2,...]]
+
+  <remote>   Name of the git remote (e.g., origin, upstream)
+  <branch>   Branch name to push to (e.g., v1.0.10.dev7/corona)
+  [dirs]     Optional comma-separated or space-separated list of directories
+             to push. If omitted, you will be prompted interactively.
+EOF
+  exit 1
+}
+
+# Check for minimum arguments needed: remote repo name and branch
+if [ $# -lt 2 ]; then
+  usage
+fi
+
+remote=$1
+branch=$2
+shift 2
+
+#Get the directories to push
+#gotta be an array if we need to support multiple dirs.
+declare -a dirs
+
+if [ $# -gt 0 ]; then
+  # User provided directories as comma- or space-separated
+  if [[ "$*" == *","* ]]; then
+    IFS=',' read -ra dirs <<< "$*"
+  else
+    dirs=("$@")
+  fi
+else
+  # Interactive selection: list top-level dirs excluding .git and whatever is hidden
+  mapfile -t all_dirs < <(
+    find . -type d \
+      | sed -e 's|^\./||' \
+      | awk -F/ 'NF==1 && $1!="" && $1!=".git" {print}'
+  )
+  if [ ${#all_dirs[@]} -eq 0 ]; then
+    echo "No directories found in current working directory." >&2
+    exit 1
+  fi
+
+  echo "Select directories to push (comma-separated indices), or 'all':"
+  for i in "${!all_dirs[@]}"; do
+    printf "%3d) %s\n" "$((i+1))" "${all_dirs[i]}"
+  done
+  printf "%3d) %s\n" "$(( ${#all_dirs[@]} + 1 ))" "all"
+
+  read -rp "Enter choice(s): " choice
+  if [[ "$choice" == "all" ]]; then
+    dirs=("${all_dirs[@]}")
+  else
+    # Split on commas or whitespace
+    if [[ "$choice" == *","* ]]; then
+      IFS=',' read -ra temp_indices <<< "$choice"
+    else
+      read -ra temp_indices <<< "$choice"
+    fi
+    for raw in "${temp_indices[@]}"; do
+      idx=$(echo "$raw" | xargs)
+      # Skip empty tokens
+      if [ -z "$idx" ]; then
+        continue
+      fi
+      if ! [[ "$idx" =~ ^[0-9]+$ ]]; then
+        echo "Invalid index: '$raw'" >&2
+        exit 1
+      fi
+      if (( idx >= 1 && idx <= ${#all_dirs[@]} )); then
+        dirs+=("${all_dirs[idx-1]}")
+      else
+        echo "Index out of range: $idx" >&2
+        exit 1
+      fi
+    done
+  fi
+fi
+
+#verify git repository
+if ! git rev-parse --git-dir &>/dev/null; then
+  echo "Error: Not a git repository." >&2
+  exit 1
+fi
+
+#bail if remote does not exist
+if ! git remote get-url "$remote" &>/dev/null; then
+  echo "Error: Remote '$remote' not found." >&2
+  exit 1
+fi
+
+#fetch and checkout branch
+git fetch "$remote" "$branch"
+git checkout -B "$branch" "$remote/$branch"
+
+#initialize sparse-checkout if needed
+git sparse-checkout init --cone 2>/dev/null || true
+
+#add directories to sparse-checkout
+for d in "${dirs[@]}"; do
+  git sparse-checkout add "$d"
+done
+
+#stage and commit changes
+git add "${dirs[@]}"
+if git diff --cached --quiet; then
+  echo "No changes to commit for: ${dirs[*]}"
+else
+  git commit -m "Add directories: ${dirs[*]}"
+fi
+
+#push to remote
+git push "$remote" "$branch"
+
+echo "Pushed directories: ${dirs[*]} to $remote/$branch"
+

--- a/script/git_sparse_push_interactive
+++ b/script/git_sparse_push_interactive
@@ -2,10 +2,10 @@
 # This script is intended to be run at the root of your local clone
 # Example usage: 
 #   For interactive usage:
-#   ./git_sparse_push_interactive.sh upstream v1.0.10.dev6/corona   
+#   ./git_sparse_push_interactive.sh -r upstream -b v1.0.10.dev6/corona
 #
 #   For non-interative usage: 
-#   ./git_sparse_push_interactive.sh upstream v1.0.10.dev6/corona test_app3_v100,test_app4_v100
+#   ./git_sparse_push_interactive.sh -r upstream -b v1.0.10.dev6/corona -d test_app3_v100,test_app4_v100
 #  !! For non-interactive usage, please make sure to not include spaces between names of dirs
 #     as shown above
 
@@ -17,37 +17,44 @@ IFS=$'\n\t'
 
 usage() {
   cat <<EOF
-Usage: $0 <remote> <branch> [dir1[,dir2,...]]
+Usage: $0 -r <remote> -b <branch> [-d <dir1[,dir2,...]>]
 
-  <remote>   Name of the git remote (e.g., origin, upstream)
-  <branch>   Branch name to push to (e.g., v1.0.10.dev7/corona)
-  [dirs]     Optional comma-separated or space-separated list of directories
-             to push. If omitted, you will be prompted interactively.
+  -r   Name of the git remote (e.g., origin, upstream)
+  -b   Branch name to push to (e.g., v1.0.10.dev7/corona)
+  -d   Optional comma-separated or space-separated list of directories
+       to push. If omitted, you will be prompted interactively.
 EOF
   exit 1
 }
 
-# Check for minimum arguments needed: remote repo name and branch
-if [ $# -lt 2 ]; then
+#parse options
+remote=""
+branch=""
+declare -a dirs
+
+while getopts ":r:b:d:" opt; do
+  case $opt in
+    r) remote="$OPTARG" ;;
+    b) branch="$OPTARG" ;;
+    d) 
+      if [[ "$OPTARG" == *","* ]]; then
+        IFS=',' read -ra dirs <<< "$OPTARG"
+      else
+        dirs=("$OPTARG")
+      fi
+      ;;
+    :) echo "Error: Option -$OPTARG requires an argument." >&2; usage ;;
+    \?) echo "Error: Invalid option -$OPTARG" >&2; usage ;;
+  esac
+done
+
+#check mandatory args
+if [[ -z "$remote" || -z "$branch" ]]; then
   usage
 fi
 
-remote=$1
-branch=$2
-shift 2
-
-#Get the directories to push
-#gotta be an array if we need to support multiple dirs.
-declare -a dirs
-
-if [ $# -gt 0 ]; then
-  # User provided directories as comma- or space-separated
-  if [[ "$*" == *","* ]]; then
-    IFS=',' read -ra dirs <<< "$*"
-  else
-    dirs=("$@")
-  fi
-else
+# Interactive selection if dirs not provided
+if [ ${#dirs[@]} -eq 0 ]; then
   # Interactive selection: list top-level dirs excluding .git and whatever is hidden
   mapfile -t all_dirs < <(
     find . -type d \


### PR DESCRIPTION
This WIP PR adds scripts to enable interactive sparse Git clone and push of trace directories without requiring full local git clone of the traces repository. 

A few outstanding things: 
~- Modify specification of parameters (add an option for each parameter)~
~- Extensively test edge cases for interactive and non-interactive usage~
~- Update documentation to correctly reflect the parameters and usage~
