### PR TITLE
Fix bugs in decorator style of AI logging

### DIFF
--- a/dftracer/dbg/logger/ai.py
+++ b/dftracer/dbg/logger/ai.py
@@ -33,6 +33,8 @@ INIT_NAME = "init"
 BLOCK_NAME = "block"
 ITER_NAME = "iter"
 CTX_SEPARATOR = "."
+ROOT_NAME = "ai_root"
+ROOT_CAT = "ai_root"
 
 def get_iter_block_name(name: str):
     return f"{name}{CTX_SEPARATOR}{BLOCK_NAME}" if not name.endswith(f"{CTX_SEPARATOR}{BLOCK_NAME}") else name
@@ -618,7 +620,7 @@ class _AI(DFTracerAI):
         image_size: Optional[Any] = None,
         enable: bool = True,
     ):
-        super().__init__(cat="root", name="root", epoch=epoch, step=step, image_idx=image_idx, image_size=image_size, enable=enable)
+        super().__init__(cat=ROOT_CAT, name=ROOT_NAME, epoch=epoch, step=step, image_idx=image_idx, image_size=image_size, enable=enable)
         self.compute = _Compute(epoch=epoch, step=step, image_idx=image_idx, image_size=image_size, enable=enable)
         self.data = _Data(epoch=epoch, step=step, image_idx=image_idx, image_size=image_size, enable=enable)
         self.dataloader = _DataLoader(epoch=epoch, step=step, image_idx=image_idx, image_size=image_size, enable=enable)

--- a/dftracer/dbg/logger/ai.py
+++ b/dftracer/dbg/logger/ai.py
@@ -349,7 +349,7 @@ class DFTracerAI(_DFTracerAI):
             image_size=self.profiler._arguments.get("image_size"),
             enable=self.profiler._enable,
         )
-        self._children[name] = child
+        self._children[_name] = child
         return child
 
 

--- a/dftracer/logger/ai.py
+++ b/dftracer/logger/ai.py
@@ -33,6 +33,8 @@ INIT_NAME = "init"
 BLOCK_NAME = "block"
 ITER_NAME = "iter"
 CTX_SEPARATOR = "."
+ROOT_NAME = "ai_root"
+ROOT_CAT = "ai_root"
 
 def get_iter_block_name(name: str):
     return f"{name}{CTX_SEPARATOR}{BLOCK_NAME}" if not name.endswith(f"{CTX_SEPARATOR}{BLOCK_NAME}") else name
@@ -618,7 +620,7 @@ class _AI(DFTracerAI):
         image_size: Optional[Any] = None,
         enable: bool = True,
     ):
-        super().__init__(cat="root", name="root", epoch=epoch, step=step, image_idx=image_idx, image_size=image_size, enable=enable)
+        super().__init__(cat=ROOT_CAT, name=ROOT_NAME, epoch=epoch, step=step, image_idx=image_idx, image_size=image_size, enable=enable)
         self.compute = _Compute(epoch=epoch, step=step, image_idx=image_idx, image_size=image_size, enable=enable)
         self.data = _Data(epoch=epoch, step=step, image_idx=image_idx, image_size=image_size, enable=enable)
         self.dataloader = _DataLoader(epoch=epoch, step=step, image_idx=image_idx, image_size=image_size, enable=enable)

--- a/dftracer/logger/ai.py
+++ b/dftracer/logger/ai.py
@@ -349,7 +349,7 @@ class DFTracerAI(_DFTracerAI):
             image_size=self.profiler._arguments.get("image_size"),
             enable=self.profiler._enable,
         )
-        self._children[name] = child
+        self._children[_name] = child
         return child
 
 

--- a/docs/ai_logging.rst
+++ b/docs/ai_logging.rst
@@ -408,6 +408,9 @@ Derivation
 Since sometimes our logging needs to be more dynamic, you can derive new profilers from existing ones. 
 This is useful when you want to create a specialized profiler with the same context as an existing one.
 
+The derived profiler becomes a child of the original profiler, inheriting its context and metadata.
+All methods like ``update``, ``enable``, and ``disable`` work on the derived profiler as expected.
+
 Example:
 
 .. code-block:: python
@@ -433,3 +436,10 @@ Example:
     def collate_fn(batch):
         with profiler_collate:
             return collate(batch)
+
+    # Update
+    profiler_collate.update(epoch=epoch)
+    # This also works:
+    ## this will update all children of ai.data.preprocess
+    ## inckuding the derived profiler such as `collate`
+    ai.data.preprocess.update(epoch=epoch) 

--- a/docs/ai_logging.rst
+++ b/docs/ai_logging.rst
@@ -441,5 +441,5 @@ Example:
     profiler_collate.update(epoch=epoch)
     # This also works:
     ## this will update all children of ai.data.preprocess
-    ## inckuding the derived profiler such as `collate`
+    ## including the derived profiler such as `collate`
     ai.data.preprocess.update(epoch=epoch) 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -154,7 +154,7 @@ set_property(TEST ${test_name} APPEND PROPERTY ENVIRONMENT DFTRACER_LOG_FILE=${C
 set_property(TEST ${test_name} APPEND PROPERTY ENVIRONMENT DFTRACER_INIT=PRELOAD)
 set_property(TEST ${test_name} APPEND PROPERTY ENVIRONMENT DFTRACER_INC_METADATA=1)
 
-df_add_test(check_file_exists_${test_name} ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/check_file.sh ${CMAKE_CURRENT_BINARY_DIR}/${test_name}*-app.pfw 38)
+df_add_test(check_file_exists_${test_name} ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/check_file.sh ${CMAKE_CURRENT_BINARY_DIR}/${test_name}*-app.pfw 71)
 set_tests_properties(check_file_exists_${test_name} PROPERTIES DEPENDS ${test_name})
 
 ## Disable DFTracer
@@ -196,7 +196,7 @@ set_property(TEST ${test_name} APPEND PROPERTY ENVIRONMENT DFTRACER_LOG_FILE=${C
 set_property(TEST ${test_name} APPEND PROPERTY ENVIRONMENT DFTRACER_INIT=PRELOAD)
 set_property(TEST ${test_name} APPEND PROPERTY ENVIRONMENT DFTRACER_INC_METADATA=1)
 
-df_add_test(check_file_exists_${test_name} ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/check_file.sh ${CMAKE_CURRENT_BINARY_DIR}/${test_name}*-app.pfw 25)
+df_add_test(check_file_exists_${test_name} ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/check_file.sh ${CMAKE_CURRENT_BINARY_DIR}/${test_name}*-app.pfw 56)
 set_tests_properties(check_file_exists_${test_name} PROPERTIES DEPENDS ${test_name})
 
 ### Device category
@@ -211,7 +211,7 @@ set_property(TEST ${test_name} APPEND PROPERTY ENVIRONMENT DFTRACER_LOG_FILE=${C
 set_property(TEST ${test_name} APPEND PROPERTY ENVIRONMENT DFTRACER_INIT=PRELOAD)
 set_property(TEST ${test_name} APPEND PROPERTY ENVIRONMENT DFTRACER_INC_METADATA=1)
 
-df_add_test(check_file_exists_${test_name} ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/check_file.sh ${CMAKE_CURRENT_BINARY_DIR}/${test_name}*-app.pfw 37)
+df_add_test(check_file_exists_${test_name} ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/check_file.sh ${CMAKE_CURRENT_BINARY_DIR}/${test_name}*-app.pfw 65)
 set_tests_properties(check_file_exists_${test_name} PROPERTIES DEPENDS ${test_name})
 
 ### Compute category
@@ -226,7 +226,7 @@ set_property(TEST ${test_name} APPEND PROPERTY ENVIRONMENT DFTRACER_LOG_FILE=${C
 set_property(TEST ${test_name} APPEND PROPERTY ENVIRONMENT DFTRACER_INIT=PRELOAD)
 set_property(TEST ${test_name} APPEND PROPERTY ENVIRONMENT DFTRACER_INC_METADATA=1)
 
-df_add_test(check_file_exists_${test_name} ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/check_file.sh ${CMAKE_CURRENT_BINARY_DIR}/${test_name}*-app.pfw 29)
+df_add_test(check_file_exists_${test_name} ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/check_file.sh ${CMAKE_CURRENT_BINARY_DIR}/${test_name}*-app.pfw 47)
 set_tests_properties(check_file_exists_${test_name} PROPERTIES DEPENDS ${test_name})
 
 #########################################################################


### PR DESCRIPTION
Hi @hariharan-devarajan,

This PR fixes the decorator-style AI logging bug where I was incorrectly using `dft_fn` context manager instead of the current `DFTracerAI` class context manager. This caused the same flushing issue as #284.

I also added a `derive` method that lets users create subcategories dynamically. This is useful for operations that don't exist in our predefined categories but logically belong under an existing one.

For example:
```python
@ai.data.preprocess.derive(name="collate")
def collate(data):
    # processing data here...
    return data

# or context manager style
profiler_collate = ai.data.preprocess.derive(name="collate")
def collate(data):
    with profiler_collate:
         # processing data here...
         return data
```

Since "collate" doesn't exist in our standard categories but is conceptually part of preprocessing, users can now easily profile it under the `data` category. The event name becomes `preprocess.collate` with `cat="data"`.

The PR includes test cases and documentation updates.